### PR TITLE
Adding DeviceId, PacketId and FirmwareVersion support

### DIFF
--- a/src/BtHomeV2Device.cpp
+++ b/src/BtHomeV2Device.cpp
@@ -20,6 +20,26 @@ BtHomeV2Device::BtHomeV2Device(const char *shortName, const char *completeName, 
 BtHomeV2Device::BtHomeV2Device(const char *shortName, const char *completeName, bool isTriggerBased, uint8_t const* const key, const uint8_t macAddress[BLE_MAC_ADDRESS_LENGTH], uint32_t counter) : _baseDevice(shortName, completeName, isTriggerBased, key, macAddress, counter){
 }
 
+bool BtHomeV2Device::addDeviceTypeId(uint16_t deviceTypeId)
+{
+    return _baseDevice.addUnsignedInteger(device_type_ID, deviceTypeId);
+}
+bool BtHomeV2Device::addPacketId(uint8_t packetId)
+{
+    return _baseDevice.addUnsignedInteger(packet_id, packetId);
+}
+
+bool BtHomeV2Device::addFirmwareVersion3(uint8_t major, uint8_t minor, uint8_t patch)
+{
+    uint32_t fwVersion = major << 16 | minor << 8 | patch;
+    return _baseDevice.addUnsignedInteger(device_type_ID, fwVersion);
+}
+bool BtHomeV2Device::addFirmwareVersion4(uint8_t major, uint8_t minor, uint8_t patch, uint8_t build)
+{
+    uint32_t fwVersion = major << 24 | minor << 16 | patch << 8 | build;
+    return _baseDevice.addUnsignedInteger(device_type_ID, fwVersion);
+}
+
 bool BtHomeV2Device::addTemperature_neg44_to_44_Resolution_0_35(float degreesCelsius)
 {
     return _baseDevice.addFloat(temperature_int8_scale_0_35, degreesCelsius);

--- a/src/BtHomeV2Device.h
+++ b/src/BtHomeV2Device.h
@@ -32,6 +32,13 @@ public:
 
     void clearMeasurementData();
 
+    bool addDeviceTypeId(uint16_t deviceTypeId);
+    bool addPacketId(uint8_t packetId);
+
+    // Currently not implemented in Home Assistant, but defined in BThome
+    bool addFirmwareVersion3(uint8_t major, uint8_t minor, uint8_t patch);
+    bool addFirmwareVersion4(uint8_t major, uint8_t minor, uint8_t patch, uint8_t build);
+
     /**
      * @brief Set a generic count value in the packet.
      * @param count Arbitrary count (e.g., event count).

--- a/src/data_types.h
+++ b/src/data_types.h
@@ -29,6 +29,10 @@ struct BtHomeType : public BtHomeState
 };
 
 // Now BtHomeType has 'id' from BtHomeState, plus its own fields.
+const BtHomeType device_type_ID = {0xF0, 1.0f, 2, false};
+const BtHomeType firmware_3_bytes = {0xF2, 1.0f, 3, false};
+const BtHomeType firmware_4_bytes = {0xF1, 1.0f, 4, false};
+const BtHomeType packet_id = {0x00, 1.0f, 1, false};
 
 const BtHomeType temperature_int8 = {0x57, 1.0f, 1, true};
 const BtHomeType temperature_int8_scale_0_35 = {0x58, 0.35f, 1, true};


### PR DESCRIPTION
I added some data types, already defined by BThome. Unfortunately, the FW version is not yet supported by Home Assistant, but Packet Id is... (see https://bthome.io/format/)