### PR TITLE
Update BaseDevice.cpp

### DIFF
--- a/src/BaseDevice.cpp
+++ b/src/BaseDevice.cpp
@@ -119,9 +119,18 @@ bool BaseDevice::addFloat(BtHomeType sensor, float value)
     return false;
   }
 
-  float factor = sensor.scale;
-  float scaledValue = value / factor;
-  return pushBytes(static_cast<uint64_t>(scaledValue), sensor);
+  float scaledValue = value / sensor.scale;
+
+  if (sensor.signed_value)
+  {
+    int64_t v = (int64_t)scaledValue;          // ujemne OK
+    return pushBytes((uint64_t)v, sensor);     // bajty polecą w U2
+  }
+  else
+  {
+    if (scaledValue < 0) scaledValue = 0;      // albo return false;
+    return pushBytes((uint64_t)scaledValue, sensor);
+  }
 }
 
 bool BaseDevice::pushBytes(uint64_t value2, BtHomeState sensor)


### PR DESCRIPTION
Fix incorrect handling of signed float values in BaseDevice::addFloat().
Negative values were lost due to direct casting from float to uint64_t.
This change respects sensor.signed_value and correctly encodes signed values using two’s complement, while preserving existing behavior for unsigned sensors.